### PR TITLE
Add: Header 및 Footer 구현

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,0 +1,52 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  position: absolute;
+  top: 103px;
+  width: 100%;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  background: #7cabe2;
+  z-index: 2;
+`;
+const SubContainer = styled.div`
+  width: 70%;
+  height: 100%;
+  display: flex;
+`;
+const Items = styled.section`
+  display: flex;
+  align-items: center;
+`;
+const Item = styled.div`
+  width: 80px;
+  height: 55px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 40px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+`;
+
+const Drawer = ({ hovered }) => {
+  const items = Array(hovered)
+    .fill("")
+    .concat(["⋅\u00A0\u00A0스피드 개인전", "⋅\u00A0\u00A0스피드 팀전"]);
+  return (
+    <Container>
+      <SubContainer>
+        <Items>
+          {items.map((item, index) => (
+            <Item key={index}>{item}</Item>
+          ))}
+        </Items>
+      </SubContainer>
+    </Container>
+  );
+};
+
+export default Drawer;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const Container = styled.div`
   position: absolute;
-  top: 103px;
+  top: 111px;
   width: 100%;
   height: 36px;
   display: flex;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,80 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.section`
+  width: 100%;
+  height: 82px;
+  display: flex;
+  justify-content: center;
+  background: #fafafa;
+`;
+const SubContainer = styled.div`
+  width: 1000px;
+  height: 100%;
+  display: flex;
+`;
+const Inner = styled.div`
+  width: 1000px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const Logos = styled.div`
+  height: 46px;
+  display: flex;
+  align-items: center;
+`;
+const Img = styled.img`
+  width: 140px;
+  margin-right: 10px;
+  opacity: 0.3;
+`;
+const Desc = styled.span`
+  width: 250px;
+  padding-left: 10px;
+  border-left: 1px solid #ccc;
+  font-size: 12px;
+  font-family: Noto Sans KR;
+  letter-spacing: -1px;
+  color: #a1a1a1;
+`;
+
+const Items = styled.div`
+  width: 100%;
+  height: 26px;
+  display: flex;
+`;
+
+const Item = styled.span`
+  margin-top: 10px;
+  padding-right: 10px;
+  margin-right: 10px;
+  color: #a1a1a1;
+  font-size: 12px;
+  letter-spacing: -1px;
+  cursor: pointer;
+`;
+
+const Footer = () => {
+  const items = ["About TMI", "문의/피드백", "업데이트로그", "채용"];
+
+  return (
+    <Container>
+      <SubContainer>
+        <Inner>
+          <Logos>
+            <Img src="https://tmi.nexon.com/img/assets/lab_logo.svg" />
+            <Desc>Data based on NEXON DEVELOPERS</Desc>
+          </Logos>
+          <Items>
+            {items.map((item) => (
+              <Item key={item}>{item}</Item>
+            ))}
+          </Items>
+        </Inner>
+      </SubContainer>
+    </Container>
+  );
+};
+
+export default Footer;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretUp } from "@fortawesome/free-solid-svg-icons";
+import Nav from "./Nav";
+import Drawer from "./Drawer";
+import Others from "./Others";
+
+const Outer = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const Util = styled.div`
+  width: 1000px;
+  height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const Inner = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+const LogoContainer = styled.div`
+  height: 48px;
+  display: flex;
+  align-items: center;
+  color: #ccc;
+`;
+const Logo = styled.img`
+  object-fit: contain;
+  padding-left: 8px;
+  box-sizing: border-box;
+`;
+const KartRiderLogo = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  :hover {
+    background: #f2f2f2;
+  }
+`;
+const IconContainer = styled.div`
+  font-size: 12px;
+  margin: 5px;
+`;
+const TMILogo = styled.div`
+  cursor: pointer;
+`;
+
+const Homepage = styled.span`
+  font-size: 12px;
+  font-weight: 600;
+  color: #6c7a89;
+  cursor: pointer;
+`;
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const Header = ({ searchData }) => {
+  const [hovered, setHovered] = useState(null);
+  const [isOthersOpen, setIsOthersOpen] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  // Nav의 "카트", "트랙" item을 hover할때 나타나는 Drawer의 state
+
+  const handleOthers = () => {
+    setIsOthersOpen((isOthersOpen) => !isOthersOpen);
+  };
+
+  const openDrawer = () => {
+    setIsDrawerOpen(true);
+  };
+  // Drawer on
+  const closeDrawer = () => {
+    setIsDrawerOpen(false);
+  };
+  // Drawer off
+  const onMouseLeave = () => {
+    closeDrawer();
+  };
+  // mouse가 떠났을 때 Drawer off하기
+
+  return (
+    <Outer>
+      <Util>
+        <Inner>
+          <LogoContainer>
+            <KartRiderLogo onClick={handleOthers}>
+              <Logo src="https://tmi.nexon.com/img/assets/logo_kart.png" />
+              <IconContainer>
+                {isOthersOpen ? (
+                  <FontAwesomeIcon icon={faCaretUp} />
+                ) : (
+                  <FontAwesomeIcon icon={faCaretDown} />
+                )}
+              </IconContainer>
+            </KartRiderLogo>
+            {isOthersOpen ? <Others /> : null}
+            <TMILogo>
+              <Logo src="https://tmi.nexon.com/img/assets/tmi_logo_default_b.svg" />
+            </TMILogo>
+          </LogoContainer>
+          <a
+            href="https://kart.nexon.com/Main/Index.aspx"
+            style={{ textDecoration: "none" }}
+          >
+            <Homepage>카트라이더 홈페이지 바로가기</Homepage>
+          </a>
+        </Inner>
+      </Util>
+      <Container onMouseLeave={onMouseLeave}>
+        <Nav
+          setHovered={setHovered}
+          openDrawer={openDrawer}
+          closeDrawer={closeDrawer}
+          searchData={searchData}
+        />
+        {isDrawerOpen ? <Drawer hovered={hovered} /> : null}
+      </Container>
+    </Outer>
+  );
+};
+
+export default Header;

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,0 +1,165 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+
+const Container = styled.div`
+  width: 100%;
+  height: 55px;
+  display: flex;
+  justify-content: center;
+  background-color: #005fcc;
+`;
+const Inner = styled.div`
+  width: 1000px;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Items = styled.section`
+  display: flex;
+`;
+const Item = styled.div`
+  width: 80px;
+  height: 55px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 40px;
+  box-sizing: border-box;
+  border-bottom: ${({ clicked, index }) =>
+    clicked === index ? "4px solid white" : null};
+  font-weight: ${({ clicked, index }) => (clicked === index ? "700" : null)};
+  color: #fff;
+  opacity: ${({ clicked, index }) => (clicked === index ? "1" : "0.5")};
+  transition: all 0.15s ease-in-out;
+  :hover {
+    border-bottom: 4px solid white;
+    font-weight: 700;
+    opacity: 1;
+  }
+`;
+const Text = styled.a`
+  margin-bottom: ${({ clicked, index }) => (clicked === index ? "-4px" : null)};
+  ${Item}:hover & {
+    margin-bottom: -4px;
+    transition: all 0.15s ease-in-out;
+  }
+`;
+
+const SearchContainer = styled.div`
+  width: 220px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  padding-right: 15px;
+  margin-left: 285px;
+  border-bottom: 1px solid #fff;
+  font-size: 12px;
+  color: white;
+  opacity: 0.5;
+  transition: 0.3s;
+  :hover {
+    opacity: 1;
+  }
+  :focus {
+    opacity: 1;
+  }
+`;
+
+const Search = styled.input`
+  width: 195px;
+  height: 32px;
+  padding-left: 10px;
+  padding-right: 25px;
+  margin-left: auto;
+  border: none;
+  color: white;
+  background: none;
+  opacity: 0.8;
+  font-weight: 700;
+  outline: none;
+  ::placeholder {
+    color: white;
+  }
+  :focus::placeholder {
+    color: transparent;
+  }
+`;
+
+const IconContainer = styled.div`
+  cursor: pointer;
+`;
+
+const Nav = ({
+  setHovered,
+  openDrawer,
+  closeDrawer,
+  searchData,
+  setIsLoading,
+  setUserData,
+}) => {
+  const items = ["홈", "랭킹", "카트", "트랙"];
+  const [clicked, setClicked] = useState(null);
+  // 클릭한 아이템의 index를 저장하는 state
+  const [nickname, setNickname] = useState("");
+  // input의 value를 저장하는 state
+
+  const onClickItem = (index) => {
+    setClicked(index);
+  };
+
+  const onMouseEnter = (index) => {
+    if (index === 2) {
+      setHovered(2);
+      openDrawer();
+    } else if (index === 3) {
+      setHovered(3);
+      openDrawer();
+    } else {
+      setHovered(null);
+      closeDrawer();
+    }
+  };
+
+  const onChangeInput = (event) => {
+    setNickname(event.target.value);
+    console.log(nickname);
+  };
+
+  return (
+    <Container>
+      <Inner>
+        <Items>
+          {items.map((item, index) => (
+            <Item
+              key={item}
+              clicked={clicked}
+              index={index}
+              onClick={() => onClickItem(index)}
+              onMouseEnter={() => onMouseEnter(index)}
+            >
+              <Text clicked={clicked} index={index}>
+                {item}
+              </Text>
+            </Item>
+          ))}
+        </Items>
+        <SearchContainer>
+          <Search
+            placeholder="닉네임 검색"
+            value={nickname}
+            onChange={onChangeInput}
+          />
+          <IconContainer onClick={() => searchData(nickname)}>
+            <FontAwesomeIcon icon={faMagnifyingGlass} />
+          </IconContainer>
+        </SearchContainer>
+      </Inner>
+    </Container>
+  );
+};
+
+export default Nav;

--- a/src/components/Others.js
+++ b/src/components/Others.js
@@ -1,0 +1,71 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  top: 48px;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  background: white;
+  z-index: 2;
+`;
+const OthersHeading = styled.div`
+  height: 31px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  font-weight: 400;
+  color: #07f;
+  cursor: pointer;
+`;
+const OthersGame = styled.div`
+  height: 30px;
+  display: flex;
+  align-items: center;
+  padding: 2px 10px;
+  margin-bottom: 5px;
+`;
+const KartRider = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: -1px;
+  color: black;
+  cursor: pointer;
+  :hover {
+    background: #f2f2f2;
+  }
+`;
+const GameImage = styled.img`
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  margin-right: 5px;
+`;
+
+const Others = () => {
+  return (
+    <Container>
+      <OthersHeading>
+        <img src="https://tmi.nexon.com/img/assets/icon_tmi.png" alt="TMI" />
+        &nbsp;에서 다른 게임을 보고 싶다면?
+      </OthersHeading>
+      <OthersGame>
+        <KartRider>
+          <GameImage
+            src="https://rs.nxfs.nexon.com/gameusr/19/3/uZCK25141939117.png"
+            alt="kartRider"
+          />
+          카트라이더
+        </KartRider>
+      </OthersGame>
+    </Container>
+  );
+};
+
+export default Others;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
ex) structure-> main

### 변경 사항

### Header 구현

1. 카트라이더 로고 drawer 
![image](https://user-images.githubusercontent.com/84559872/160761405-c868bdcd-a84a-437a-b875-c8a989e4d815.png)
카트라이더 로고를 클릭 시, drawer가 등장합니다.
drawer의 on/off가 상태로 저장되어 있어 클릭 이벤트에 따라 drawer가 구현되고, 사라집니다.
drawer는 position 값을 absolute를 주고 z-index 값을 줌으로써 맨 앞에 위치할 수 있도록 하였습니다.

2. Nav hover에 따른 border-bottom 구현
![hoverBorderBottom](https://user-images.githubusercontent.com/84559872/160766398-837b7797-1eae-4ab1-9ea6-827f2a8646f8.gif)
Nav 부분의 item을 hover시 border-bottom이 생성됩니다.
onMouseEnter 이벤트 핸들러를 사용하여 조건부 스타일링을 줬습니다.
border-bottom이 생성되면서 밀리는 현상은 텍스트 부분의 element를 따로 생성하여 margin값을 minus로 줌으로써 해결하였습니다.

3. Nav hover에 따른 drawer구현
![hoverDrawer](https://user-images.githubusercontent.com/84559872/160766417-7158ce77-1a22-49ef-bfee-6b2f0fed44c0.gif)
Nav 부분의 특정 item을 hover시 drawer가 생성됩니다.
onMouseEnter 이벤트 핸들러를 사용하여 조건부 스타일링을 줬습니다.
drawer는 position 값을 absolute를 주고 z-index 값을 줌으로써 맨 앞에 위치할 수 있도록 하였습니다.

### Footer 구현
Footer는 단순한 구조로 설명을 첨부하지 않았습니다.