### PR TITLE
Add: Main 페이지 및 Profile 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,21 @@
       "name": "kart-match-record-clone",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/free-regular-svg-icons": "^6.1.1",
+        "@fortawesome/free-solid-svg-icons": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.1.18",
+        "@reduxjs/toolkit": "^1.8.0",
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.26.1",
+        "date-fns": "^2.28.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
+        "styled-components": "^5.3.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -1970,6 +1979,29 @@
         "postcss": "^8.3"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
@@ -2028,6 +2060,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.x"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2811,6 +2900,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.0.tgz",
+      "integrity": "sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3480,6 +3592,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3589,6 +3710,17 @@
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -4449,6 +4581,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4676,6 +4816,11 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -4994,6 +5139,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
@@ -5469,6 +5619,14 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -5649,6 +5807,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -5861,6 +6029,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -6213,14 +6393,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dotenv-expand": {
@@ -7964,6 +8136,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -13237,6 +13422,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13317,6 +13526,14 @@
         }
       }
     },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13373,6 +13590,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -13515,6 +13748,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -13982,6 +14220,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14377,6 +14620,51 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/babel-plugin-styled-components": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
+      "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/stylehacks": {
@@ -17401,6 +17689,29 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "requires": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "@eslint/eslintrc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
@@ -17443,6 +17754,43 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -18004,6 +18352,17 @@
         }
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.0.tgz",
+      "integrity": "sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -18480,6 +18839,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -18589,6 +18957,17 @@
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/resolve": {
@@ -19218,6 +19597,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -19386,6 +19773,11 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -19636,6 +20028,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -19997,6 +20394,11 @@
         "postcss-selector-parser": "^6.0.9"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -20103,6 +20505,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -20260,6 +20672,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -20529,11 +20946,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -21783,6 +22195,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -25453,6 +25880,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -25511,6 +25951,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "readable-stream": {
@@ -25557,6 +26004,20 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -25667,6 +26128,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -26000,6 +26466,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -26298,6 +26769,37 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "requires": {}
+    },
+    "styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "babel-plugin-styled-components": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
+          "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.16.0",
+            "@babel/helper-module-imports": "^7.16.0",
+            "babel-plugin-syntax-jsx": "^6.18.0",
+            "lodash": "^4.17.11",
+            "picomatch": "^2.3.0"
+          }
+        }
+      }
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,21 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-regular-svg-icons": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.1.18",
+    "@reduxjs/toolkit": "^1.8.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.26.1",
+    "date-fns": "^2.28.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
+    "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,63 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useGetDatasQuery, useGetMatchDatasQuery } from "./services/api";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import Loading from "./components/Loading";
+import Main from "./pages/Main";
+
+const BlankMain = styled.div`
+  width: 100%;
+  height: 800px;
+`;
+
 function App() {
-  return <div className="App"></div>;
+  const [nickname, setNickname] = useState("BBEESSTT");
+
+  const { data, error, isLoading, isFetching, refetch } =
+    useGetDatasQuery(nickname);
+
+  // console.log(data);
+
+  const {
+    data: matchData,
+    error: matchDataError,
+    isLoading: matchDataIsLoading,
+    isFetching: matchDataIsFetching,
+    isSuccess: matchDataIsSuccess,
+  } = useGetMatchDatasQuery(data?.accessId);
+
+  // console.log(matchData);
+
+  return (
+    <div className="App">
+      <Header setNickname={setNickname} />
+      {isFetching || matchDataIsFetching ? (
+        <>
+          <Loading />
+          <BlankMain>
+            <h2>...Fetching</h2>
+          </BlankMain>
+        </>
+      ) : isLoading || matchDataIsLoading ? (
+        <>
+          <Loading />
+          <BlankMain>
+            <h2>...Loading</h2>
+          </BlankMain>
+        </>
+      ) : error || matchDataError ? (
+        <BlankMain>
+          <h2>sth wrong</h2>
+        </BlankMain>
+      ) : matchDataIsSuccess ? (
+        <Main
+        // data={matchData} updateData={refetch}
+        />
+      ) : null}
+      <Footer />
+    </div>
+  );
 }
 
 export default App;

--- a/src/components/AlertModal.js
+++ b/src/components/AlertModal.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+
+const Dim = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 12;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  width: 300px;
+  padding: 25px;
+  background: white;
+  z-index: 13;
+`;
+
+const SubContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const Title = styled.div`
+  font-weight: 700;
+  color: #1f334a;
+`;
+const Desc = styled.div`
+  font-size: 14px;
+  color: #1f334a;
+`;
+const Buttons = styled.section`
+  width: 100%;
+  height: 32px;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+`;
+const Button = styled.div`
+  width: 50px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background-color: #07f;
+  cursor: pointer;
+`;
+
+const AlertModal = ({ closeAlert }) => {
+  return (
+    <Dim>
+      <Container>
+        <SubContainer>
+          <Title>확인</Title>
+          <Desc>신고 사유를 입력해 주세요.</Desc>
+          <Buttons>
+            <Button onClick={closeAlert}>네</Button>
+          </Buttons>
+        </SubContainer>
+      </Container>
+    </Dim>
+  );
+};
+
+export default AlertModal;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const Container = styled.div`
   position: absolute;
-  top: 111px;
+  top: 55px;
   width: 100%;
   height: 36px;
   display: flex;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -62,12 +62,13 @@ const Homepage = styled.span`
   cursor: pointer;
 `;
 const Container = styled.section`
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
 `;
 
-const Header = ({ searchData }) => {
+const Header = ({ setNickname }) => {
   const [hovered, setHovered] = useState(null);
   const [isOthersOpen, setIsOthersOpen] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -123,7 +124,7 @@ const Header = ({ searchData }) => {
           setHovered={setHovered}
           openDrawer={openDrawer}
           closeDrawer={closeDrawer}
-          searchData={searchData}
+          setNickname={setNickname}
         />
         {isDrawerOpen ? <Drawer hovered={hovered} /> : null}
       </Container>

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -93,18 +93,11 @@ const IconContainer = styled.div`
   cursor: pointer;
 `;
 
-const Nav = ({
-  setHovered,
-  openDrawer,
-  closeDrawer,
-  searchData,
-  setIsLoading,
-  setUserData,
-}) => {
+const Nav = ({ setHovered, openDrawer, closeDrawer, setNickname }) => {
   const items = ["홈", "랭킹", "카트", "트랙"];
   const [clicked, setClicked] = useState(null);
   // 클릭한 아이템의 index를 저장하는 state
-  const [nickname, setNickname] = useState("");
+  const [inputValue, setInputValue] = useState("");
   // input의 value를 저장하는 state
 
   const onClickItem = (index) => {
@@ -125,8 +118,13 @@ const Nav = ({
   };
 
   const onChangeInput = (event) => {
-    setNickname(event.target.value);
-    console.log(nickname);
+    setInputValue(event.target.value);
+    console.log(inputValue);
+  };
+
+  const searchData = async () => {
+    setNickname(inputValue);
+    console.log("clicked");
   };
 
   return (
@@ -150,10 +148,10 @@ const Nav = ({
         <SearchContainer>
           <Search
             placeholder="닉네임 검색"
-            value={nickname}
+            value={inputValue}
             onChange={onChangeInput}
           />
-          <IconContainer onClick={() => searchData(nickname)}>
+          <IconContainer onClick={searchData}>
             <FontAwesomeIcon icon={faMagnifyingGlass} />
           </IconContainer>
         </SearchContainer>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,0 +1,273 @@
+import React, { useState, useRef } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faUser,
+  faUsers,
+  faArrowRotateRight,
+  faBell,
+  faShareAlt,
+  faEye,
+} from "@fortawesome/free-solid-svg-icons";
+import ReportModal from "./ReportModal";
+
+const Container = styled.section`
+  width: 1000px;
+  height: 177px;
+  background: transparent;
+  border-left: 4px solid #07f;
+  z-index: 0;
+`;
+const Background = styled.img`
+  position: absolute;
+  width: 1000px;
+  height: inherit;
+  object-fit: cover;
+  z-index: 1;
+`;
+const Nick = styled.div`
+  position: absolute;
+  width: 70%;
+  height: 150px;
+  display: flex;
+  background: transparent;
+  padding-top: 26px;
+  z-index: 2;
+`;
+const Character = styled.img`
+  width: 164px;
+  height: 123px;
+  object-fit: cover;
+`;
+const Name = styled.div`
+  width: 511px;
+  height: 123px;
+  display: flex;
+  flex-direction: column;
+`;
+const Heading = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 45px;
+  font-weight: 900;
+  font-family: Noto Sans KR;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const License = styled.img`
+  width: 25px;
+  height: 25px;
+  margin-left: 10px;
+`;
+const Buttons = styled.div`
+  display: flex;
+`;
+const TeamSelect = styled.div`
+  display: flex;
+  width: 220px;
+  height: 50px;
+  padding-right: 15px;
+`;
+const Indi = styled.span`
+  width: 100%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  font-weight: 700;
+  font-size: 12px;
+  border: 1px solid #07f;
+  border-radius: 5px 0 0 5px;
+  color: ${({ isTeam }) => (isTeam ? "#07f" : "white")};
+  background: ${({ isTeam }) => (isTeam ? "white" : "#2777ff")};
+  cursor: pointer;
+  :hover {
+    color: white;
+    background: #2777ff;
+  }
+`;
+const Team = styled.span`
+  width: 100%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid #07f;
+  border-radius: 0 5px 5px 0;
+  color: ${({ isTeam }) => (isTeam ? "white" : "#07f")};
+  background: ${({ isTeam }) => (isTeam ? "#2777ff" : "white")};
+  cursor: pointer;
+  :hover {
+    color: white;
+    background: #2777ff;
+  }
+`;
+const TeamIconContainer = styled.div`
+  font-size: 12px;
+  margin-right: 10px;
+`;
+
+const Line = styled.div`
+  width: 1px;
+  height: 14px;
+  margin-top: 26px;
+  background: #ececec;
+`;
+
+const UserAction = styled.div`
+  display: flex;
+  width: 280px;
+  height: 50px;
+  margin-left: 10px;
+  color: #1f334a;
+  letter-spacing: -1px;
+  cursor: pointer;
+`;
+
+const Action = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 82px;
+  height: 25px;
+  margin-top: 20px;
+  margin-right: 10px;
+  font-size: 12px;
+  border: 0.7px solid #1f334a;
+  border-radius: 15px;
+  color: #1f334a;
+  overflow: hidden;
+`;
+const ActionIconContainer = styled.div`
+  font-size: 12px;
+  margin-right: 10px;
+`;
+const Views = styled.section`
+  width: 325px;
+  height: 123px;
+  display: flex;
+  align-content: center;
+`;
+const ViewsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-left: 200px;
+`;
+const ViewsDesc = styled.div`
+  font-size: 14px;
+  font-family: Noto Sans KR;
+  color: #6c7a89;
+  white-space: nowrap;
+`;
+const ViewsNum = styled.div`
+  font-size: 20px;
+  color: #6c7a89;
+  letter-spacing: -1px;
+`;
+
+const UrlContainer = styled.textarea`
+  position: absolute;
+  left: -100%;
+`;
+
+const Profile = ({ data, updateData, isTeam, setIsTeam }) => {
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const matchDatas = data.matches?.[0].matches[0];
+  const copyUrlRef = useRef();
+
+  const openReport = () => {
+    setIsReportOpen(true);
+  };
+
+  const closereport = () => {
+    setIsReportOpen(false);
+  };
+
+  const indiSelect = () => {
+    setIsTeam(false);
+  };
+
+  const teamSelect = () => {
+    setIsTeam(true);
+  };
+
+  const copyUrl = () => {
+    copyUrlRef.current.select();
+
+    document.execCommand("copy");
+    alert("url이 복사되었습니다.");
+  };
+
+  return (
+    <Container>
+      <UrlContainer ref={copyUrlRef} value={window.location.href} readOnly />
+      {isReportOpen ? <ReportModal closereport={closereport} /> : null}
+      <Background src="https://tmi.nexon.com/img/background_flag_w.png" />
+      <Nick>
+        <Character
+          src={`https://s3-ap-northeast-1.amazonaws.com/solution-userstats/metadata/character/${matchDatas?.character}.png`}
+        />
+        <Name>
+          <Heading>
+            {data.nickName}
+            <License src="https://tmi.nexon.com/img/icon_l3.png" />
+          </Heading>
+          <Buttons>
+            <TeamSelect>
+              <Indi isTeam={isTeam} onClick={indiSelect}>
+                <TeamIconContainer>
+                  <FontAwesomeIcon icon={faUser} />
+                </TeamIconContainer>
+                개인전
+              </Indi>
+              <Team isTeam={isTeam} onClick={teamSelect}>
+                <TeamIconContainer>
+                  <FontAwesomeIcon icon={faUsers} />
+                </TeamIconContainer>
+                팀전
+              </Team>
+            </TeamSelect>
+            <Line />
+            <UserAction>
+              <Action onClick={updateData}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faArrowRotateRight} />
+                </ActionIconContainer>
+                전적갱신
+              </Action>
+              <Action onClick={openReport}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faBell} />
+                </ActionIconContainer>
+                신고하기
+              </Action>
+              <Action onClick={copyUrl}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faShareAlt} />
+                </ActionIconContainer>
+                공유하기
+              </Action>
+            </UserAction>
+          </Buttons>
+        </Name>
+        <Views>
+          <ViewsBox>
+            <ViewsDesc>
+              <FontAwesomeIcon icon={faEye} />
+              &nbsp;페이지뷰
+            </ViewsDesc>
+            <ViewsNum>2000</ViewsNum>
+          </ViewsBox>
+        </Views>
+      </Nick>
+    </Container>
+  );
+};
+
+export default Profile;

--- a/src/components/ReportModal.js
+++ b/src/components/ReportModal.js
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import AlertModal from "./AlertModal";
+
+const Dim = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  width: 300px;
+  padding: 25px;
+  background: white;
+  z-index: 11;
+`;
+
+const SubContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const Title = styled.div`
+  font-weight: 700;
+  color: #1f334a;
+`;
+const Desc = styled.div`
+  font-size: 14px;
+  color: #1f334a;
+`;
+const Textarea = styled.textarea`
+  height: 100px;
+  padding: 0 10px;
+  margin-top: 20px;
+  font-size: 14px;
+  box-sizing: border-box;
+  resize: none;
+`;
+const Buttons = styled.section`
+  width: 100%;
+  height: 32px;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+`;
+const Button = styled.div`
+  width: 50px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background-color: #07f;
+  cursor: pointer;
+`;
+const ReportModal = ({ closereport }) => {
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [desc, setDesc] = useState("");
+
+  const openAlert = () => {
+    setIsAlertOpen(true);
+  };
+  const closeAlert = () => {
+    setIsAlertOpen(false);
+  };
+
+  const onChange = (text) => {
+    setDesc(text);
+  };
+
+  const alert = () => {
+    if (desc === "") {
+      openAlert();
+    } else {
+      closereport();
+    }
+  };
+
+  return (
+    <Dim>
+      {isAlertOpen ? <AlertModal closeAlert={closeAlert} /> : null}
+      <Container>
+        <SubContainer>
+          <Title>유저신고</Title>
+          <Desc>해당 유저를 신고하겠습니까?</Desc>
+          <Desc>신고하시려면 사유를 입력해 주세요.</Desc>
+          <Textarea value={desc} onChange={(e) => onChange(e.target.value)} />
+          <Buttons>
+            <Button onClick={closereport}>아니오</Button>
+            <Button onClick={alert}>네</Button>
+          </Buttons>
+        </SubContainer>
+      </Container>
+    </Dim>
+  );
+};
+
+export default ReportModal;

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { Provider } from "react-redux";
+import { store } from "./redux/store";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import Profile from "../components/Profile";
+
+const Outer = styled.section`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.025);
+`;
+const Inner = styled.div`
+  width: 1000px;
+  display: flex;
+  flex-direction: column;
+`;
+const ApiInfo = styled.div`
+  height: 50px;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const IconContainer = styled.div`
+  font-size: 13px;
+  margin-right: 5px;
+`;
+
+const Main = ({ data, updateData }) => {
+  const [isTeam, setIsTeam] = useState(false);
+  // 개인전인지 팀전인지 여부
+
+  return (
+    <Outer>
+      <Inner>
+        <ApiInfo>
+          <IconContainer>
+            <FontAwesomeIcon icon={faCircleInfo} />
+          </IconContainer>
+          카트라이더 매치데이터는 최근 1년치 데이터만 확인할 수 있습니다
+        </ApiInfo>
+        <Profile
+          data={data}
+          updateData={updateData}
+          isTeam={isTeam}
+          setIsTeam={setIsTeam}
+        />
+      </Inner>
+    </Outer>
+  );
+};
+
+export default Main;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { setupListeners } from "@reduxjs/toolkit/dist/query";
+import { datasApi } from "../services/api";
+
+export const store = configureStore({
+  reducer: {
+    [datasApi.reducerPath]: datasApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(datasApi.middleware),
+});
+
+setupListeners(store.dispatch);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,33 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const datasApi = createApi({
+  reducerPath: "datasApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl:
+      "https://joseph-proxy.herokuapp.com/https://api.nexon.co.kr/kart/v1.0",
+    prepareHeaders: (headers) => {
+      headers.set("Authorization", process.env.REACT_APP_API_KEY);
+      return headers;
+    },
+  }),
+  endpoints: (builder) => ({
+    getDatas: builder.query({
+      query: (nickname) => `/users/nickname/${nickname}`,
+    }),
+    getMatchDatas: builder.query({
+      query: (access_Id) => `/users/${access_Id}/matches?limit=50`,
+    }),
+    getPlayerDatas: builder.mutation({
+      query: (match_Id) => ({
+        url: `/matches/${match_Id}`,
+        method: "GET",
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetDatasQuery,
+  useGetMatchDatasQuery,
+  useGetPlayerDatasMutation,
+} = datasApi;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
ex) mainpage-> main

### 변경 사항
1. 기본 페이지인 main.js 기초 구조 완성
컴포넌트들을 차근차근 채워나갈 예정입니다. <br><br>
2. 신고 modal
신고하기 버튼을 누르면 유저신고 modal이 생성됩니다.
![image](https://user-images.githubusercontent.com/84559872/161216974-4d71ba69-9226-4daa-b4e1-751fc6ab360a.png)
아무 사유도 입력하지 않을 시 확인 modal이 생성됩니다.
![image](https://user-images.githubusercontent.com/84559872/161217023-29a68044-f0e5-49fd-99b3-2d1cbcf7cf0d.png) <br><br>
3. 공유하기(url 복사)
공유하기 버튼을 누르면 alert창이 나옵니다. 현재 위치한 url이 복사됩니다. 
![image](https://user-images.githubusercontent.com/84559872/161217244-d085dafc-af57-43c5-97cc-065858a40215.png) <br><br>
4. data props
현재 api를 통해 받아온 data를 props로 내려받고 있습니다.
Header쪽 input에서 nickname을 검색 시 새로운 data를 내려받고, profile의 내용들도 변화합니다.
![profile_props](https://user-images.githubusercontent.com/84559872/161218186-070bc223-4d53-4f07-ba2b-94993bff7193.gif) <br><br>
5. 기타
아직 페이지뷰(조회수)는 구현되지 않았습니다.


