### PR TITLE
Add: 매치데이터 및 drawer 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,21 @@
       "name": "kart-match-record-clone",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/free-regular-svg-icons": "^6.1.1",
+        "@fortawesome/free-solid-svg-icons": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.1.18",
+        "@reduxjs/toolkit": "^1.8.0",
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.26.1",
+        "date-fns": "^2.28.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
+        "styled-components": "^5.3.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -1970,6 +1979,29 @@
         "postcss": "^8.3"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
@@ -2028,6 +2060,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.x"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2811,6 +2900,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.0.tgz",
+      "integrity": "sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3480,6 +3592,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3589,6 +3710,17 @@
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -4449,6 +4581,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4676,6 +4816,11 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -4994,6 +5139,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
@@ -5469,6 +5619,14 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -5649,6 +5807,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -5861,6 +6029,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -6213,14 +6393,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dotenv-expand": {
@@ -7964,6 +8136,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -13237,6 +13422,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13317,6 +13526,14 @@
         }
       }
     },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13373,6 +13590,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -13515,6 +13748,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -13982,6 +14220,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14377,6 +14620,51 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/babel-plugin-styled-components": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
+      "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/stylehacks": {
@@ -17401,6 +17689,29 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "requires": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "@eslint/eslintrc": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
@@ -17443,6 +17754,43 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-xXiW7hcpgwmWtndKPOzG+43fPH7ZjxOaoeyooptSztGmJxCAflHZxXNK0GcT0uEsR4jTGQAfGklDZE5NHoBhKg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -18004,6 +18352,17 @@
         }
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.0.tgz",
+      "integrity": "sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -18480,6 +18839,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -18589,6 +18957,17 @@
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/resolve": {
@@ -19218,6 +19597,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -19386,6 +19773,11 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -19636,6 +20028,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -19997,6 +20394,11 @@
         "postcss-selector-parser": "^6.0.9"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
@@ -20103,6 +20505,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -20260,6 +20672,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -20529,11 +20946,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -21783,6 +22195,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -25453,6 +25880,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -25511,6 +25951,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "readable-stream": {
@@ -25557,6 +26004,20 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -25667,6 +26128,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -26000,6 +26466,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -26298,6 +26769,37 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "requires": {}
+    },
+    "styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "babel-plugin-styled-components": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
+          "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.16.0",
+            "@babel/helper-module-imports": "^7.16.0",
+            "babel-plugin-syntax-jsx": "^6.18.0",
+            "lodash": "^4.17.11",
+            "picomatch": "^2.3.0"
+          }
+        }
+      }
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,21 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-regular-svg-icons": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.1.18",
+    "@reduxjs/toolkit": "^1.8.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.26.1",
+    "date-fns": "^2.28.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
+    "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,63 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useGetDatasQuery, useGetMatchDatasQuery } from "./services/api";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import Loading from "./components/Loading";
+import Main from "./pages/Main";
+
+const BlankMain = styled.div`
+  width: 100%;
+  height: 800px;
+`;
+
 function App() {
-  return <div className="App"></div>;
+  const [nickname, setNickname] = useState("BBEESSTT");
+
+  const { data, error, isLoading, isFetching, refetch } =
+    useGetDatasQuery(nickname);
+
+  // console.log(data);
+
+  const {
+    data: matchData,
+    error: matchDataError,
+    isLoading: matchDataIsLoading,
+    isFetching: matchDataIsFetching,
+    isSuccess: matchDataIsSuccess,
+  } = useGetMatchDatasQuery(data?.accessId);
+
+  // console.log(matchData);
+
+  return (
+    <div className="App">
+      <Header setNickname={setNickname} />
+      {isFetching || matchDataIsFetching ? (
+        <>
+          <Loading />
+          <BlankMain>
+            <h2>...Fetching</h2>
+          </BlankMain>
+        </>
+      ) : isLoading || matchDataIsLoading ? (
+        <>
+          <Loading />
+          <BlankMain>
+            <h2>...Loading</h2>
+          </BlankMain>
+        </>
+      ) : error || matchDataError ? (
+        <BlankMain>
+          <h2>sth wrong</h2>
+        </BlankMain>
+      ) : matchDataIsSuccess ? (
+        <Main
+        // data={matchData} updateData={refetch}
+        />
+      ) : null}
+      <Footer />
+    </div>
+  );
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -51,9 +51,7 @@ function App() {
           <h2>sth wrong</h2>
         </BlankMain>
       ) : matchDataIsSuccess ? (
-        <Main
-        // data={matchData} updateData={refetch}
-        />
+        <Main data={matchData} updateData={refetch} />
       ) : null}
       <Footer />
     </div>

--- a/src/components/AlertModal.js
+++ b/src/components/AlertModal.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+
+const Dim = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 12;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  width: 300px;
+  padding: 25px;
+  background: white;
+  z-index: 13;
+`;
+
+const SubContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const Title = styled.div`
+  font-weight: 700;
+  color: #1f334a;
+`;
+const Desc = styled.div`
+  font-size: 14px;
+  color: #1f334a;
+`;
+const Buttons = styled.section`
+  width: 100%;
+  height: 32px;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+`;
+const Button = styled.div`
+  width: 50px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background-color: #07f;
+  cursor: pointer;
+`;
+
+const AlertModal = ({ closeAlert }) => {
+  return (
+    <Dim>
+      <Container>
+        <SubContainer>
+          <Title>확인</Title>
+          <Desc>신고 사유를 입력해 주세요.</Desc>
+          <Buttons>
+            <Button onClick={closeAlert}>네</Button>
+          </Buttons>
+        </SubContainer>
+      </Container>
+    </Dim>
+  );
+};
+
+export default AlertModal;

--- a/src/components/Cheering.js
+++ b/src/components/Cheering.js
@@ -1,0 +1,210 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const Container = styled.section`
+  width: 350px;
+  height: 265px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 12px;
+  margin-right: 10px;
+  background: white;
+  box-sizing: border-box;
+`;
+const Heading = styled.header`
+  width: 100%;
+  height: 41px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  border-bottom: 1px solid #ccc;
+  color: #1f334a;
+  box-sizing: border-box;
+`;
+const Title = styled.div``;
+const Blue = styled.span`
+  color: #2877ff;
+`;
+const Black = styled.span``;
+
+const Total = styled.div`
+  font-size: 12px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const MessageBox = styled.section`
+  width: 100%;
+  height: 159px;
+  padding: 0 5px;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+const Message = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+`;
+const NickName = styled.div`
+  display: flex;
+  height: 53px;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
+  font-size: 12px;
+  white-space: nowrap;
+  color: #07f;
+`;
+
+const ContensBox = styled.div`
+  position: relative;
+  width: 100%;
+  height: 41px;
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  margin: 6px;
+  font-size: 12px;
+  border: 1px solid #c3ced5;
+  border-radius: 15px;
+  box-sizing: border-box;
+`;
+const Contents = styled.span`
+  ::before {
+    content: "";
+    position: absolute;
+    width: 5px;
+    height: 5px;
+    display: flex;
+    align-items: center;
+    margin-left: -14px;
+    border-left: 1px solid #c3ced5;
+    border-bottom: 1px solid #c3ced5;
+    background: white;
+    transform: rotate(0.125turn);
+  }
+  display: flex;
+  align-items: center;
+  margin: 0;
+`;
+const Bottom = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  margin: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  border-top: 1px solid #f2f2f2;
+`;
+const NickInput = styled.input`
+  width: 15%;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1px 2px;
+  margin-right: 5px;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  font-family: Noto Sans KR;
+  font-size: 12px;
+  font-weight: 500;
+`;
+const MessageInput = styled.input`
+  width: 60%;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  padding: 1px 2px;
+  margin-right: 5px;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  font-family: Noto Sans KR;
+  font-size: 12px;
+  font-weight: 500;
+`;
+const Button = styled.div`
+  width: 53px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+  color: white;
+  background: #ccc;
+  cursor: pointer;
+`;
+const data = [
+  { name: "탱크", contents: "보이스스스" },
+  { name: "오이", contents: "나는 오이!" },
+  { name: "바나나", contents: "바부부" },
+];
+
+const Cheering = () => {
+  const [messages, setMessages] = useState(data);
+  const [nick, setNick] = useState("");
+  const [contents, setContents] = useState("");
+
+  const onChangeNick = (text) => {
+    setNick(text);
+  };
+  const onChangeContents = (text) => {
+    if (text.length <= 30) {
+      setContents(text);
+    } // 30자 제한
+  };
+  const addMessage = () => {
+    let temp = { name: nick, contents: contents };
+
+    if (nick !== "" && contents !== "") {
+      // 닉네임과 내용이 빈 문자열이 아닐 때 작동.
+      setMessages([...messages, temp]);
+      setNick("");
+      setContents("");
+    } else {
+      alert("닉네임 혹은 내용이 입력되지 않았습니다.");
+    }
+  };
+
+  return (
+    <Container>
+      <Heading>
+        <Title>
+          <Blue>응원</Blue> <Black>한마디</Black>
+        </Title>
+        <Total>오늘 0개&nbsp; 전체 {messages.length}개</Total>
+      </Heading>
+      <MessageBox>
+        {messages.map((message, index) => (
+          <Message key={index}>
+            <NickName>{message.name}</NickName>
+            <ContensBox>
+              <Contents>{message.contents}</Contents>
+            </ContensBox>
+          </Message>
+        ))}
+      </MessageBox>
+      <Bottom>
+        <NickInput
+          placeholder="닉네임"
+          value={nick}
+          onChange={(e) => onChangeNick(e.target.value)}
+        />
+        <MessageInput
+          placeholder="최대 30자"
+          value={contents}
+          onChange={(e) => onChangeContents(e.target.value)}
+        />
+        <Button onClick={addMessage}>남기기</Button>
+      </Bottom>
+    </Container>
+  );
+};
+
+export default Cheering;

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const Container = styled.div`
   position: absolute;
-  top: 111px;
+  top: 55px;
   width: 100%;
   height: 36px;
   display: flex;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -62,12 +62,13 @@ const Homepage = styled.span`
   cursor: pointer;
 `;
 const Container = styled.section`
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
 `;
 
-const Header = ({ searchData }) => {
+const Header = ({ setNickname }) => {
   const [hovered, setHovered] = useState(null);
   const [isOthersOpen, setIsOthersOpen] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -123,7 +124,7 @@ const Header = ({ searchData }) => {
           setHovered={setHovered}
           openDrawer={openDrawer}
           closeDrawer={closeDrawer}
-          searchData={searchData}
+          setNickname={setNickname}
         />
         {isDrawerOpen ? <Drawer hovered={hovered} /> : null}
       </Container>

--- a/src/components/Info.js
+++ b/src/components/Info.js
@@ -1,0 +1,22 @@
+import React from "react";
+import styled from "styled-components";
+import Left from "./Left";
+import Right from "./Right";
+
+const Container = styled.section`
+  width: 100%;
+  min-height: 800px;
+  display: flex;
+  margin-top: 20px;
+`;
+
+const Info = ({ data, isTeam, isRetire }) => {
+  return (
+    <Container>
+      <Left data={data} />
+      <Right data={data} isTeam={isTeam} isRetire={isRetire} />
+    </Container>
+  );
+};
+
+export default Info;

--- a/src/components/Left.js
+++ b/src/components/Left.js
@@ -1,0 +1,219 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  width: 330px;
+  display: flex;
+  flex-direction: column;
+  margin-right: 10px;
+`;
+const Tabs = styled.div`
+  display: flex;
+`;
+const Tab = styled.div`
+  width: 116px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 14px;
+  border-bottom: ${({ clicked, index }) =>
+    clicked === index ? "2px solid #0277ff" : "2px solid transparent"};
+  color: ${({ clicked, index }) => (clicked === index ? "#0277ff" : "gray")};
+  background: ${({ clicked, index }) =>
+    clicked === index ? "white" : "#ebebeb"};
+`;
+
+const TopTable = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: white;
+`;
+const TableTitle = styled.div`
+  width: 288px;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  margin-top: 15px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  border-bottom: 1px solid #ccc;
+`;
+
+const TitleBox = styled.div`
+  font-size: 14px;
+`;
+const PercentBox = styled.div`
+  font-size: 12px;
+`;
+const Blue = styled.span`
+  color: #2877ff;
+`;
+const Black = styled.span``;
+
+const Graph = styled.div`
+  width: 288px;
+  height: 178px;
+  padding: 15px 8px;
+`;
+const Title = styled.div`
+  width: 100%;
+  font-size: 14px;
+  font-weight: 500;
+  color: #1f334a;
+`;
+const Gray = styled.span`
+  color: #a1a1a1;
+`;
+const LineGraphBox = styled.section`
+  width: 100%;
+  height: 140px;
+  padding: 10px 0;
+  border: 1px solid black;
+`;
+
+const BottomTable = styled.div`
+  width: 310px;
+  height: 235px;
+  display: flex;
+  flex-direction: column;
+  padding-right: 18px;
+  background: white;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+const Thead = styled.section`
+  width: 100%;
+  height: 35px;
+  display: grid;
+  grid-template-columns: 25px 160px 25px 33px 40px 27px;
+  background: #f9f9f9;
+`;
+const Th = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: -1px;
+`;
+const Tbody = styled.div`
+  width: 100%;
+  height: 200px;
+`;
+const Tr = styled.section`
+  width: 100%;
+  height: 46px;
+  display: grid;
+  grid-template-columns: 25px 160px 25px 33px 40px 27px;
+  justify-items: center;
+  align-items: center;
+`;
+const Radio = styled.input``;
+const Track = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 10px;
+  font-size: 13px;
+  color: #1f334a;
+`;
+const TrackImage = styled.img`
+  height: 27px;
+  margin-right: 5px;
+`;
+const Td = styled.div`
+  text-align: center;
+  font-size: 13px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+
+const Left = ({ data }) => {
+  const tabs = ["트랙", "카트"];
+  const TrackRecord = Array(5).fill("");
+
+  const [clicked, setClicked] = useState(0);
+  const [radioChecked, setRadioChecked] = useState(0);
+
+  const onClickTab = (index) => {
+    setClicked(index);
+  };
+  const onClickRadio = (index) => {
+    setRadioChecked(index);
+  };
+
+  return (
+    <Container>
+      <Tabs>
+        {tabs.map((tab, index) => (
+          <Tab
+            key={index}
+            clicked={clicked}
+            index={index}
+            onClick={() => onClickTab(index)}
+          >
+            {tab}
+          </Tab>
+        ))}
+      </Tabs>
+      <TopTable>
+        <TableTitle>
+          <TitleBox>
+            <Blue>트랙</Blue>&nbsp;
+            <Black>전적</Black>
+          </TitleBox>
+          <PercentBox>
+            평균 상위&nbsp;
+            <Blue>8.68</Blue>%
+          </PercentBox>
+        </TableTitle>
+        <Graph>
+          <Title>
+            브로디 비밀의 연구소&nbsp;<Gray>기록분포</Gray>
+          </Title>
+          <LineGraphBox></LineGraphBox>
+        </Graph>
+      </TopTable>
+      <BottomTable>
+        <Thead>
+          <Th>선택</Th>
+          <Th>트랙</Th>
+          <Th>횟수</Th>
+          <Th>승률</Th>
+          <Th>기록</Th>
+          <Th>상위</Th>
+        </Thead>
+        <Tbody>
+          {TrackRecord.map((track, index) => (
+            <Tr key={index}>
+              <Radio
+                type="radio"
+                name="track"
+                Checked={radioChecked === index}
+                onClick={() => onClickRadio(index)}
+              />
+              <Track>
+                <TrackImage
+                  src="https://s3-ap-northeast-1.amazonaws.com/solution-userstats/kartimg/Category/brodi_1.png"
+                  alt="트랙이미지"
+                />
+                브로디 비밀의 연구
+              </Track>
+              <Td>13</Td>
+              <Td>38%</Td>
+              <Td>2'13'72</Td>
+              <Td>15%</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </BottomTable>
+    </Container>
+  );
+};
+
+export default Left;

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,47 @@
+import React from "react";
+import styled, { keyframes } from "styled-components";
+
+const CircleAnimation = keyframes`
+  from {
+    transform: translate(-50%, -50%) rotate(0);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+`;
+const Circle = styled.div`
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 50px;
+  height: 50px;
+  border: 5px solid #fff;
+  border-top: 5px solid #0277ff;
+  border-radius: 30px;
+  transition: all 0.3s;
+  animation-name: ${CircleAnimation};
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  z-index: 12;
+`;
+const Dim = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 11;
+`;
+const Loading = () => {
+  return (
+    <>
+      <Dim />
+      <Circle />
+    </>
+  );
+};
+
+export default Loading;

--- a/src/components/MatchDetail.js
+++ b/src/components/MatchDetail.js
@@ -1,0 +1,358 @@
+import React, { useState } from "react";
+import styled, { keyframes } from "styled-components";
+import { useGetPlayerDatasMutation } from "../services/api";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
+import { ko } from "date-fns/locale";
+import { convertTrackId, convertKart, convertRecord } from "./convert";
+
+const MatchBox = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Match = styled.div`
+  width: 100%;
+  height: 88px;
+  display: grid;
+  grid-template-columns: 65px 150px 150px 150px 100px 40px;
+  margin-bottom: 5px;
+  border-left: ${({ rank }) =>
+    rank === "" || rank === "99"
+      ? "4px solid #f62459"
+      : rank === "1"
+      ? "4px solid #07f"
+      : "4px solid #8893a2"};
+  color: "#1f334a";
+  background: ${({ rank }) =>
+    rank === "" || rank === "99"
+      ? "#fbf0f2"
+      : rank === "1"
+      ? "#eff3fb"
+      : "white"};
+`;
+const Type = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+`;
+const Result = styled.span`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 10px;
+  font-size: 30px;
+  font-weight: 700;
+  font-style: italic;
+  color: ${({ rank }) =>
+    rank === "" || rank === "99"
+      ? "#f62459"
+      : rank === "1"
+      ? "#07f"
+      : "#1f334a"};
+  opacity: ${({ rank }) =>
+    rank === "" || rank === "99" ? "1" : rank === "1" ? "1" : "0.5"};
+  box-sizing: border-box;
+`;
+const ResultTotal = styled.span`
+  margin-left: 5px;
+  margin-bottom: -10px;
+  font-size: 16px;
+  font-style: italic;
+`;
+const Track = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const Kart = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const Time = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 500;
+`;
+const Open = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 12px;
+  opacity: 0.3;
+  cursor: pointer;
+  :hover {
+    background: ${({ rank }) =>
+      rank === "" || rank === "99"
+        ? "#f62459"
+        : rank === "1"
+        ? "#07f"
+        : "#1f334a"};
+  }
+`;
+
+const Details = styled.section`
+  width: 100%;
+  height: 175px;
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+`;
+
+const Detail = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  font-weight: ${({ myAccountNo, accountNo }) =>
+    myAccountNo === accountNo ? "700" : "400"};
+`;
+
+const DetailRank = styled.div`
+  width: 100%;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${({ matchRank }) =>
+    matchRank === "99" || matchRank === "0"
+      ? "red"
+      : matchRank === "1"
+      ? "#0277ff"
+      : "black"};
+  background: ${({ myAccountNo, accountNo, matchRank }) =>
+    (matchRank === "1") & (myAccountNo === accountNo) ? "#e5ecf6" : "#f2f2f2"};
+`;
+
+const DetailKart = styled.div`
+  width: 100%;
+  height: 78px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${({ myAccountNo, accountNo }) =>
+    myAccountNo === accountNo ? "#f2f2f2" : "white"};
+`;
+const DetailKartImage = styled.img`
+  width: 80%;
+  height: 80%;
+  object-fit: contain;
+`;
+const DetailNick = styled.div`
+  width: 100%;
+  height: 17px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${({ myAccountNo, accountNo }) =>
+    myAccountNo === accountNo ? "#f2f2f2" : "white"};
+`;
+const DetailTime = styled.div`
+  width: 100%;
+  height: 42px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${({ myAccountNo, accountNo }) =>
+    myAccountNo === accountNo ? "#f2f2f2" : "white"};
+`;
+const animation = keyframes` 
+    0% {
+        background: rgba(165, 165, 165, 0.1);
+    }
+
+    50% {
+      background: rgba(165, 165, 165, 0.3);
+    }
+
+    100% {
+      background: rgba(165, 165, 165, 0.1);
+    }
+`;
+
+const LoadingDetails = styled.section`
+  width: 100%;
+  height: 175px;
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+`;
+const LoadingDetail = styled.div`
+  width: 73px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const LoadingDetailRank = styled.div`
+  width: 100%;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: ${animation};
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+`;
+const MatchDetail = ({ matchData }) => {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [players, setPlayers] = useState({});
+
+  const [getPlayerDatas, result] = useGetPlayerDatasMutation();
+  const { isError, isLoading, isSuccess } = result;
+  // 어떻게 쓸지 모르겠음 과연 아래의 방식이 맞을까?
+  const getPlayerData = async (matchId) => {
+    let datas = await getPlayerDatas(matchId);
+    setPlayers(datas.data);
+  };
+
+  const handleDetail = (matchId) => {
+    setDetailOpen((detailOpen) => !detailOpen);
+    getPlayerData(matchId);
+  };
+
+  return matchData === null ? null : (
+    <MatchBox>
+      <Match rank={matchData.player.matchRank}>
+        <Type>
+          {formatDistanceToNow(new Date(matchData.endTime), { locale: ko }) +
+            " 전"}
+        </Type>
+        <Result rank={matchData.player.matchRank}>
+          {matchData.player.matchRank === "" ||
+          matchData.player.matchRank === "99" ? (
+            "#리타이어"
+          ) : (
+            <>
+              #{Number(matchData.player.matchRank)}
+              <ResultTotal>/{matchData.playerCount}</ResultTotal>
+            </>
+          )}
+        </Result>
+        <Track>{convertTrackId(matchData.trackId)}</Track>
+        <Kart>{convertKart(matchData.player.kart)}</Kart>
+        <Time>{convertRecord(matchData.player.matchTime)}</Time>
+        <Open
+          rank={matchData.player.matchRank}
+          onClick={() => handleDetail(matchData.matchId)}
+        >
+          <FontAwesomeIcon icon={faCaretDown} />
+        </Open>
+      </Match>
+      {detailOpen ? (
+        isLoading ? (
+          <LoadingDetails>
+            {Array(9)
+              .fill("")
+              .map((_, index) => (
+                <LoadingDetail key={index}>
+                  <LoadingDetailRank />
+                  <DetailKart />
+                  <DetailNick />
+                  <DetailTime />
+                </LoadingDetail>
+              ))}
+          </LoadingDetails>
+        ) : (
+          <Details>
+            <Detail>
+              <DetailRank>#</DetailRank>
+              <DetailKart>카트</DetailKart>
+              <DetailNick>유저</DetailNick>
+              <DetailTime>기록</DetailTime>
+            </Detail>
+            {players.players === undefined
+              ? players.teams?.map((team) =>
+                  team?.players.map((member) => (
+                    <Detail
+                      key={member.accountNo}
+                      myAccountNo={matchData.accountNo}
+                      accountNo={member.accountNo}
+                    >
+                      <DetailRank
+                        myAccountNo={matchData.accountNo}
+                        accountNo={member.accountNo}
+                        matchRank={member.matchRank}
+                      >
+                        {member.matchRank === "99" || member.matchRank === "0"
+                          ? "리타이어 "
+                          : member.matchRank}
+                      </DetailRank>
+                      <DetailKart
+                        myAccountNo={matchData.accountNo}
+                        accountNo={member.accountNo}
+                      >
+                        <DetailKartImage
+                          src={`https://s3-ap-northeast-1.amazonaws.com/solution-userstats/metadata/kart/${member.kart}.png?v=1648453384`}
+                          onError={(e) => {
+                            e.target.src =
+                              "https://tmi.nexon.com/img/assets/empty_kart.png";
+                          }}
+                        />
+                      </DetailKart>
+                      <DetailNick
+                        myAccountNo={matchData.accountNo}
+                        accountNo={member.accountNo}
+                      >
+                        {member.characterName}
+                      </DetailNick>
+                      <DetailTime
+                        myAccountNo={matchData.accountNo}
+                        accountNo={member.accountNo}
+                      >
+                        {convertRecord(member.matchTime)}
+                      </DetailTime>
+                    </Detail>
+                  ))
+                )
+              : players.players?.map((player) => (
+                  <Detail
+                    key={player.accountNo}
+                    myAccountNo={matchData.accountNo}
+                    accountNo={player.accountNo}
+                  >
+                    <DetailRank
+                      myAccountNo={matchData.accountNo}
+                      accountNo={player.accountNo}
+                      matchRank={player.matchRank}
+                    >
+                      {player.matchRank === "99" || player.matchRank === "0"
+                        ? "리타이어 "
+                        : player.matchRank}
+                    </DetailRank>
+                    <DetailKart
+                      myAccountNo={matchData.accountNo}
+                      accountNo={player.accountNo}
+                    >
+                      <DetailKartImage
+                        src={`https://s3-ap-northeast-1.amazonaws.com/solution-userstats/metadata/kart/${player.kart}.png?v=1648453384`}
+                        onError={(e) =>
+                          (e.target.src =
+                            "https://tmi.nexon.com/img/assets/empty_kart.png")
+                        }
+                      />
+                    </DetailKart>
+                    <DetailNick
+                      myAccountNo={matchData.accountNo}
+                      accountNo={player.accountNo}
+                    >
+                      {player.characterName}
+                    </DetailNick>
+                    <DetailTime
+                      myAccountNo={matchData.accountNo}
+                      accountNo={player.accountNo}
+                    >
+                      {convertRecord(player.matchTime)}
+                    </DetailTime>
+                  </Detail>
+                ))}
+          </Details>
+        )
+      ) : null}
+    </MatchBox>
+  );
+};
+
+export default MatchDetail;

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -93,18 +93,11 @@ const IconContainer = styled.div`
   cursor: pointer;
 `;
 
-const Nav = ({
-  setHovered,
-  openDrawer,
-  closeDrawer,
-  searchData,
-  setIsLoading,
-  setUserData,
-}) => {
+const Nav = ({ setHovered, openDrawer, closeDrawer, setNickname }) => {
   const items = ["홈", "랭킹", "카트", "트랙"];
   const [clicked, setClicked] = useState(null);
   // 클릭한 아이템의 index를 저장하는 state
-  const [nickname, setNickname] = useState("");
+  const [inputValue, setInputValue] = useState("");
   // input의 value를 저장하는 state
 
   const onClickItem = (index) => {
@@ -125,8 +118,13 @@ const Nav = ({
   };
 
   const onChangeInput = (event) => {
-    setNickname(event.target.value);
-    console.log(nickname);
+    setInputValue(event.target.value);
+    console.log(inputValue);
+  };
+
+  const searchData = async () => {
+    setNickname(inputValue);
+    console.log("clicked");
   };
 
   return (
@@ -150,10 +148,10 @@ const Nav = ({
         <SearchContainer>
           <Search
             placeholder="닉네임 검색"
-            value={nickname}
+            value={inputValue}
             onChange={onChangeInput}
           />
-          <IconContainer onClick={() => searchData(nickname)}>
+          <IconContainer onClick={searchData}>
             <FontAwesomeIcon icon={faMagnifyingGlass} />
           </IconContainer>
         </SearchContainer>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,0 +1,273 @@
+import React, { useState, useRef } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faUser,
+  faUsers,
+  faArrowRotateRight,
+  faBell,
+  faShareAlt,
+  faEye,
+} from "@fortawesome/free-solid-svg-icons";
+import ReportModal from "./ReportModal";
+
+const Container = styled.section`
+  width: 1000px;
+  height: 177px;
+  background: transparent;
+  border-left: 4px solid #07f;
+  z-index: 0;
+`;
+const Background = styled.img`
+  position: absolute;
+  width: 1000px;
+  height: inherit;
+  object-fit: cover;
+  z-index: 1;
+`;
+const Nick = styled.div`
+  position: absolute;
+  width: 70%;
+  height: 150px;
+  display: flex;
+  background: transparent;
+  padding-top: 26px;
+  z-index: 2;
+`;
+const Character = styled.img`
+  width: 164px;
+  height: 123px;
+  object-fit: cover;
+`;
+const Name = styled.div`
+  width: 511px;
+  height: 123px;
+  display: flex;
+  flex-direction: column;
+`;
+const Heading = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 45px;
+  font-weight: 900;
+  font-family: Noto Sans KR;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const License = styled.img`
+  width: 25px;
+  height: 25px;
+  margin-left: 10px;
+`;
+const Buttons = styled.div`
+  display: flex;
+`;
+const TeamSelect = styled.div`
+  display: flex;
+  width: 220px;
+  height: 50px;
+  padding-right: 15px;
+`;
+const Indi = styled.span`
+  width: 100%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  font-weight: 700;
+  font-size: 12px;
+  border: 1px solid #07f;
+  border-radius: 5px 0 0 5px;
+  color: ${({ isTeam }) => (isTeam ? "#07f" : "white")};
+  background: ${({ isTeam }) => (isTeam ? "white" : "#2777ff")};
+  cursor: pointer;
+  :hover {
+    color: white;
+    background: #2777ff;
+  }
+`;
+const Team = styled.span`
+  width: 100%;
+  height: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  border: 1px solid #07f;
+  border-radius: 0 5px 5px 0;
+  color: ${({ isTeam }) => (isTeam ? "white" : "#07f")};
+  background: ${({ isTeam }) => (isTeam ? "#2777ff" : "white")};
+  cursor: pointer;
+  :hover {
+    color: white;
+    background: #2777ff;
+  }
+`;
+const TeamIconContainer = styled.div`
+  font-size: 12px;
+  margin-right: 10px;
+`;
+
+const Line = styled.div`
+  width: 1px;
+  height: 14px;
+  margin-top: 26px;
+  background: #ececec;
+`;
+
+const UserAction = styled.div`
+  display: flex;
+  width: 280px;
+  height: 50px;
+  margin-left: 10px;
+  color: #1f334a;
+  letter-spacing: -1px;
+  cursor: pointer;
+`;
+
+const Action = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 82px;
+  height: 25px;
+  margin-top: 20px;
+  margin-right: 10px;
+  font-size: 12px;
+  border: 0.7px solid #1f334a;
+  border-radius: 15px;
+  color: #1f334a;
+  overflow: hidden;
+`;
+const ActionIconContainer = styled.div`
+  font-size: 12px;
+  margin-right: 10px;
+`;
+const Views = styled.section`
+  width: 325px;
+  height: 123px;
+  display: flex;
+  align-content: center;
+`;
+const ViewsBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-left: 200px;
+`;
+const ViewsDesc = styled.div`
+  font-size: 14px;
+  font-family: Noto Sans KR;
+  color: #6c7a89;
+  white-space: nowrap;
+`;
+const ViewsNum = styled.div`
+  font-size: 20px;
+  color: #6c7a89;
+  letter-spacing: -1px;
+`;
+
+const UrlContainer = styled.textarea`
+  position: absolute;
+  left: -100%;
+`;
+
+const Profile = ({ data, updateData, isTeam, setIsTeam }) => {
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const matchDatas = data.matches?.[0].matches[0];
+  const copyUrlRef = useRef();
+
+  const openReport = () => {
+    setIsReportOpen(true);
+  };
+
+  const closereport = () => {
+    setIsReportOpen(false);
+  };
+
+  const indiSelect = () => {
+    setIsTeam(false);
+  };
+
+  const teamSelect = () => {
+    setIsTeam(true);
+  };
+
+  const copyUrl = () => {
+    copyUrlRef.current.select();
+
+    document.execCommand("copy");
+    alert("url이 복사되었습니다.");
+  };
+
+  return (
+    <Container>
+      <UrlContainer ref={copyUrlRef} value={window.location.href} readOnly />
+      {isReportOpen ? <ReportModal closereport={closereport} /> : null}
+      <Background src="https://tmi.nexon.com/img/background_flag_w.png" />
+      <Nick>
+        <Character
+          src={`https://s3-ap-northeast-1.amazonaws.com/solution-userstats/metadata/character/${matchDatas?.character}.png`}
+        />
+        <Name>
+          <Heading>
+            {data.nickName}
+            <License src="https://tmi.nexon.com/img/icon_l3.png" />
+          </Heading>
+          <Buttons>
+            <TeamSelect>
+              <Indi isTeam={isTeam} onClick={indiSelect}>
+                <TeamIconContainer>
+                  <FontAwesomeIcon icon={faUser} />
+                </TeamIconContainer>
+                개인전
+              </Indi>
+              <Team isTeam={isTeam} onClick={teamSelect}>
+                <TeamIconContainer>
+                  <FontAwesomeIcon icon={faUsers} />
+                </TeamIconContainer>
+                팀전
+              </Team>
+            </TeamSelect>
+            <Line />
+            <UserAction>
+              <Action onClick={updateData}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faArrowRotateRight} />
+                </ActionIconContainer>
+                전적갱신
+              </Action>
+              <Action onClick={openReport}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faBell} />
+                </ActionIconContainer>
+                신고하기
+              </Action>
+              <Action onClick={copyUrl}>
+                <ActionIconContainer>
+                  <FontAwesomeIcon icon={faShareAlt} />
+                </ActionIconContainer>
+                공유하기
+              </Action>
+            </UserAction>
+          </Buttons>
+        </Name>
+        <Views>
+          <ViewsBox>
+            <ViewsDesc>
+              <FontAwesomeIcon icon={faEye} />
+              &nbsp;페이지뷰
+            </ViewsDesc>
+            <ViewsNum>2000</ViewsNum>
+          </ViewsBox>
+        </Views>
+      </Nick>
+    </Container>
+  );
+};
+
+export default Profile;

--- a/src/components/Rank.js
+++ b/src/components/Rank.js
@@ -1,0 +1,83 @@
+import React, { useRef, useState, useEffect } from "react";
+import styled from "styled-components";
+
+const Container = styled.section`
+  width: 350px;
+  height: 265px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 12px;
+  margin-right: 10px;
+  background: white;
+  box-sizing: border-box;
+`;
+const Heading = styled.header`
+  width: 100%;
+  height: 41px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  border-bottom: 1px solid #ccc;
+  color: #1f334a;
+  box-sizing: border-box;
+`;
+const Title = styled.div``;
+const Blue = styled.span`
+  color: #2877ff;
+`;
+const Black = styled.span``;
+
+const Total = styled.div`
+  font-size: 12px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const ChartBox = styled.div`
+  width: 300px;
+  height: 180px;
+  padding: 12px;
+`;
+const Chart = styled.canvas`
+  width: 300px;
+  height: 180px;
+`;
+
+const Rank = ({ data }) => {
+  const canvasRef = useRef(null);
+  const contextRef = useRef(null);
+
+  const [ctx, setCtx] = useState();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas.getContext("2d");
+    context.strokeStyle = "black";
+    context.lineWidth = 2.5;
+    contextRef.current = context;
+
+    setCtx(contextRef.current);
+  }, []);
+
+  return (
+    <Container>
+      <Heading>
+        <Title>
+          <Blue>순위 변동</Blue> <Black>추이</Black>
+        </Title>
+        <Total>
+          지난 200경기 &nbsp;<Blue>2.81위</Blue> &nbsp; 최근 50경기 &nbsp;
+          <Blue>3.00위</Blue>
+        </Total>
+      </Heading>
+      <ChartBox>
+        <Chart ref={canvasRef}></Chart>
+      </ChartBox>
+    </Container>
+  );
+};
+
+export default Rank;

--- a/src/components/Record.js
+++ b/src/components/Record.js
@@ -1,0 +1,175 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.section`
+  width: 350px;
+  height: 265px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 12px;
+  margin-right: 10px;
+  background: white;
+  box-sizing: border-box;
+`;
+const Heading = styled.header`
+  width: 100%;
+  height: 41px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  border-bottom: 1px solid #ccc;
+  color: #1f334a;
+  box-sizing: border-box;
+`;
+const Title = styled.div``;
+const Blue = styled.span`
+  color: #2877ff;
+`;
+const Black = styled.span``;
+const WinAndLose = styled.div`
+  font-size: 12px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const Graph = styled.section`
+  width: 95%;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  margin: 0 auto;
+  font-weight: 500;
+`;
+const WinRate = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 8px 0;
+  text-align: center;
+  font-size: 14px;
+  border-right: 1px solid #f2f2f2;
+`;
+const FinishRate = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 8px 0;
+  text-align: center;
+  font-size: 14px;
+  border-right: 1px solid #f2f2f2;
+`;
+const RetireRate = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  margin: 8px 0;
+  font-size: 14px;
+`;
+const CircleBox = styled.div`
+  width: 83px;
+  height: 83px;
+  margin: 20px auto;
+`;
+const OuterCircle = styled.div`
+  width: 83px;
+  height: 83px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background: ${({ color, degree }) => `conic-gradient(
+    ${color} 0deg,
+    ${color} ${degree}deg,
+    #ebebeb ${degree}deg,
+    #ebebeb 360deg
+  )`};
+`;
+const InnerCircle = styled.div`
+  width: 68px;
+  height: 68px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background: white;
+`;
+const Percent = styled.span`
+  margin-bottom: 7px;
+  font-size: 20px;
+  color: ${({ color }) => color};
+`;
+const Bottom = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  margin: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  border-top: 1px solid #f2f2f2;
+`;
+const RunMode = styled.span`
+  font-size: 20px;
+  font-weight: 700;
+  color: #1f334a;
+`;
+const Record = ({ data }) => {
+  const degrees = [35, 91, 67];
+
+  const convertToDeg = (percent) => {
+    let degree = percent * 3.6;
+    return degree;
+  };
+
+  return (
+    <Container>
+      <Heading>
+        <Title>
+          <Blue>종합</Blue> <Black>전적</Black>
+        </Title>
+        <WinAndLose>200전 69승 131패</WinAndLose>
+      </Heading>
+      <Graph>
+        <WinRate>
+          <span>승률</span>
+          <CircleBox>
+            <OuterCircle color="#0277ff" degree={convertToDeg(degrees[0])}>
+              <InnerCircle>
+                <Percent color="#0277ff">{degrees[0]}%</Percent>
+              </InnerCircle>
+            </OuterCircle>
+          </CircleBox>
+        </WinRate>
+        <FinishRate>
+          <span>완주율</span>
+          <CircleBox>
+            <OuterCircle color="#9bd728" degree={convertToDeg(degrees[1])}>
+              <InnerCircle>
+                <Percent color="#9bd728">{degrees[1]}%</Percent>
+              </InnerCircle>
+            </OuterCircle>
+          </CircleBox>
+        </FinishRate>
+        <RetireRate>
+          <span>리타이어율</span>
+          <CircleBox>
+            <OuterCircle color="#f62559" degree={convertToDeg(degrees[2])}>
+              <InnerCircle>
+                <Percent color="#f62559">{degrees[2]}%</Percent>
+              </InnerCircle>
+            </OuterCircle>
+          </CircleBox>
+        </RetireRate>
+      </Graph>
+      <Bottom>
+        <Title>
+          <Blue>최다주행</Blue> <Black>모드</Black>
+        </Title>
+        <RunMode>통합</RunMode>
+      </Bottom>
+    </Container>
+  );
+};
+
+export default Record;

--- a/src/components/ReportModal.js
+++ b/src/components/ReportModal.js
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import AlertModal from "./AlertModal";
+
+const Dim = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  width: 300px;
+  padding: 25px;
+  background: white;
+  z-index: 11;
+`;
+
+const SubContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+const Title = styled.div`
+  font-weight: 700;
+  color: #1f334a;
+`;
+const Desc = styled.div`
+  font-size: 14px;
+  color: #1f334a;
+`;
+const Textarea = styled.textarea`
+  height: 100px;
+  padding: 0 10px;
+  margin-top: 20px;
+  font-size: 14px;
+  box-sizing: border-box;
+  resize: none;
+`;
+const Buttons = styled.section`
+  width: 100%;
+  height: 32px;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+`;
+const Button = styled.div`
+  width: 50px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background-color: #07f;
+  cursor: pointer;
+`;
+const ReportModal = ({ closereport }) => {
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [desc, setDesc] = useState("");
+
+  const openAlert = () => {
+    setIsAlertOpen(true);
+  };
+  const closeAlert = () => {
+    setIsAlertOpen(false);
+  };
+
+  const onChange = (text) => {
+    setDesc(text);
+  };
+
+  const alert = () => {
+    if (desc === "") {
+      openAlert();
+    } else {
+      closereport();
+    }
+  };
+
+  return (
+    <Dim>
+      {isAlertOpen ? <AlertModal closeAlert={closeAlert} /> : null}
+      <Container>
+        <SubContainer>
+          <Title>유저신고</Title>
+          <Desc>해당 유저를 신고하겠습니까?</Desc>
+          <Desc>신고하시려면 사유를 입력해 주세요.</Desc>
+          <Textarea value={desc} onChange={(e) => onChange(e.target.value)} />
+          <Buttons>
+            <Button onClick={closereport}>아니오</Button>
+            <Button onClick={alert}>네</Button>
+          </Buttons>
+        </SubContainer>
+      </Container>
+    </Dim>
+  );
+};
+
+export default ReportModal;

--- a/src/components/Right.js
+++ b/src/components/Right.js
@@ -1,0 +1,72 @@
+import React from "react";
+import styled from "styled-components";
+import MatchDetail from "./MatchDetail";
+import gameType from "../data/gameType.json";
+
+const Container = styled.section`
+  width: 660px;
+  padding: 40px 0;
+`;
+const Matches = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Right = ({ data, isTeam, isRetire }) => {
+  // console.log(isTeam);
+  // console.log(isExceptRetire);
+
+  const matchDatas = data.matches?.[0].matches;
+
+  let filteringData = (matchData) => {
+    let matchName = gameType.filter((e) => e.id === matchData.matchType);
+    // console.log(matchName[0].name.slice(-3));
+    if (isTeam) {
+      if (matchName[0].name.slice(-3) === "개인전") {
+        return null;
+      } else {
+        if (
+          isRetire &&
+          (matchData.player.matchRank === "" ||
+            matchData.player.matchRank === "99")
+        ) {
+          return null;
+        } else {
+          return matchData;
+        }
+      }
+    } else {
+      if (matchName[0].name.slice(-3) === "개인전") {
+        if (
+          isRetire &&
+          (matchData.player.matchRank === "" ||
+            matchData.player.matchRank === "99")
+        ) {
+          return null;
+        } else {
+          return matchData;
+        }
+      } else if (matchName[0].name.slice(-3) === " 팀전") {
+        return null;
+      }
+    }
+  };
+
+  return (
+    <Container>
+      <Matches>
+        {matchDatas?.map((matchData, index) => (
+          <MatchDetail
+            key={index}
+            matchData={filteringData(matchData)}
+            isTeam={isTeam}
+            isRetire={isRetire}
+          />
+        ))}
+      </Matches>
+    </Container>
+  );
+};
+
+export default Right;

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+import Record from "./Record";
+import Rank from "./Rank";
+import Cheering from "./Cheering";
+
+const Container = styled.section`
+  width: 100%;
+  height: 265px;
+  display: flex;
+  margin-top: 20px;
+`;
+
+const Stats = ({ data }) => {
+  return (
+    <Container>
+      <Record data={data} />
+      <Rank data={data} />
+      <Cheering />
+    </Container>
+  );
+};
+
+export default Stats;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Toggle from "./Toggle";
+
+const Container = styled.div`
+  width: 100%;
+  height: 61px;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #ccc;
+`;
+
+const Box = styled.section`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #1f334a;
+`;
+
+const Tab = styled.div`
+  width: 81px;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border-bottom: ${({ clicked, index }) =>
+    clicked === index ? "4px solid #0277ff" : "4px solid transparent"};
+  font-size: 14px;
+  font-weight: 500;
+  color: ${({ clicked, index }) => (clicked === index ? "#0277ff" : "#a1a1a1")};
+  transition: all 0.15s ease-in-out;
+  :hover {
+    border-bottom: 4px solid #0277ff;
+    color: #0277ff;
+  }
+`;
+const Text = styled.span`
+  margin-bottom: -4px;
+`;
+
+const Tabs = ({ isRetire, setIsRetire }) => {
+  const [clicked, setClicked] = useState(0);
+
+  const tabsName = ["통합", "매우빠름", "무한부스터"];
+
+  const onClickTab = (index) => {
+    setClicked(index);
+  };
+
+  return (
+    <Container>
+      <Box>
+        {tabsName.map((name, index) => (
+          <Tab
+            key={name}
+            clicked={clicked}
+            index={index}
+            onClick={() => onClickTab(index)}
+          >
+            <Text clicked={clicked} index={index}>
+              {name}
+            </Text>
+          </Tab>
+        ))}
+      </Box>
+      <Box>
+        리타이어 노출
+        <Toggle isRetire={isRetire} setIsRetire={setIsRetire} />
+      </Box>
+    </Container>
+  );
+};
+
+export default Tabs;

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -1,0 +1,49 @@
+import React from "react";
+import styled from "styled-components";
+
+const ToggleContainer = styled.div`
+  width: 34px;
+  height: 18px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-left: 10px;
+  cursor: pointer;
+`;
+const Shadow = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  border-radius: 10px;
+  background: ${({ isRetire }) => (isRetire ? "gray" : "#f62459")};
+  transition: all 0.15s ease-in-out;
+`;
+
+const Ball = styled.div`
+  position: relative;
+  width: 14px;
+  height: 14px;
+  transform: ${({ isRetire }) =>
+    isRetire ? "translate(2px, 0)" : "translate(18px, 0)"};
+  border-radius: 50%;
+  background: white;
+  transition: all 0.15s ease-in-out;
+`;
+
+const Toggle = ({ isRetire, setIsRetire }) => {
+  const handleToggle = () => {
+    setIsRetire((isRetire) => !isRetire);
+  };
+
+  return (
+    <ToggleContainer onClick={handleToggle}>
+      <Shadow isRetire={isRetire}>
+        <Ball isRetire={isRetire} />
+      </Shadow>
+    </ToggleContainer>
+  );
+};
+
+export default Toggle;

--- a/src/components/VSanimation.js
+++ b/src/components/VSanimation.js
@@ -1,0 +1,70 @@
+import React from "react";
+import styled, { keyframes } from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCalculator } from "@fortawesome/free-solid-svg-icons";
+
+const animation = keyframes`
+  0% {
+      background-position: 0 0%;
+  }
+  50% {
+      background-position: 100% 0%;
+  }
+  100% {
+      background-position: 0 0%;
+  }
+`;
+
+const Container = styled.section`
+  width: 100%;
+  height: 45px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 20px;
+  padding-left: 20px;
+  font-size: 15px;
+  font-weight: 500;
+  color: white;
+  background: linear-gradient(-45deg, #ee7752, #f62459, #07f, #23d5ab);
+  background-size: 400% 400%;
+  box-sizing: border-box;
+
+  animation: ${animation};
+  animation-duration: 20s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+`;
+
+const Text = styled.span``;
+const Button = styled.div`
+  width: 82px;
+  height: 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+  font-size: 12px;
+  font-weight: 400;
+  border: 0.7px solid #fff;
+  border-radius: 15px;
+`;
+
+const VSanimation = () => {
+  return (
+    <Container>
+      <Text>1대1 매칭 시뮬레이터 - 'BBEESSTT' 와 가상 대결을 펼쳐보세요.</Text>
+      <a
+        href="https://tmi.nexon.com/simulator/BBEESSTT"
+        style={{ textDecoration: "none", color: "white" }}
+      >
+        <Button>
+          <FontAwesomeIcon icon={faCalculator} />
+          &nbsp;&nbsp;매칭하기
+        </Button>
+      </a>
+    </Container>
+  );
+};
+
+export default VSanimation;

--- a/src/components/convert.js
+++ b/src/components/convert.js
@@ -1,0 +1,84 @@
+export const convertTrackId = (trackId) => {
+  let converted = "";
+  if (
+    trackId ===
+    "cef91d19aece7571a2e667fe0240f92a010af6c5a6cd68e11a166d69124ee432"
+  ) {
+    converted = "대저택 은밀한 지하실";
+  } else if (
+    trackId ===
+    "7394f4ea05d4115bc1308101998132e50e366c4456c6368a1800a494c6f8c0c1"
+  ) {
+    converted = "빌리지 고가의 질주";
+  } else if (
+    trackId ===
+    "799dd082c3022634391f8775089c0a25fc4df61e539772958b8a8416e0d77e6a"
+  ) {
+    converted = "팩토리 미완성 5구역";
+  } else if (
+    trackId ===
+    "c961712df23e818c056b2e673467aca3e173b7bf53ee8e35cf9a3e75a3dfc0c6"
+  ) {
+    converted = "WKC 상해 서킷";
+  } else if (
+    trackId ===
+    "936626b1d09165291db82c65c8533f6a023e1f72669741706b70835bcffb699e"
+  ) {
+    converted = "브로디 비밀의 연구소";
+  } else if (
+    trackId ===
+    "95fbb45f299b72e7e5d1f013e56d528dd5b67fae6a57a1b8ca3b2eec7ba84bfc"
+  ) {
+    converted = "차이나 서안 병마용	";
+  } else if (
+    trackId ===
+    "243ccbc7e0f66415976bd36d3718821c2af1440d16e923dca6be7a0b4bc1c02c"
+  ) {
+    converted = "	차이나 황산";
+  } else if (
+    trackId ===
+    "b57588a6c4fd89fbc2a2c9e9c1a95a746c35ab3ee08e3935db1a427121853e9a"
+  ) {
+    converted = "코리아 제주 해오름 다운힐";
+  } else {
+    converted = "아무 트랙";
+  }
+
+  return converted;
+};
+
+export const convertKart = (kart) => {
+  let converted = "";
+  if (
+    kart === "0b41bf8620b5851d7dcc7eb33765d506e530b8d2e612e6c60823f2b890da3401"
+  ) {
+    converted = "몬스터 X LE";
+  }
+  return converted;
+};
+
+export const convertRecord = (record) => {
+  let miliseconds = parseInt((record % 1000) / 10);
+  if (miliseconds < 10) {
+    miliseconds = "'0" + miliseconds;
+  } else {
+    miliseconds = "'" + miliseconds;
+  }
+
+  let seconds = parseInt((record / 1000) % 60);
+  if (seconds < 10) {
+    seconds = "'0" + seconds;
+  } else {
+    seconds = "'" + seconds;
+  }
+
+  let minutes = "" + parseInt(record / 60000);
+
+  let converted = minutes + seconds + miliseconds;
+
+  if (converted === "0'00'00") {
+    return "-";
+  } else {
+    return converted;
+  }
+};

--- a/src/data/gameType.json
+++ b/src/data/gameType.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "7ca6fd44026a2c8f5d939b60aa56b4b1714b9cc2355ec5e317154d4cf0675da0",
+    "name": "아이템 개인전"
+  },
+  {
+    "id": "01fd412de5437005a62300b6a135a546053d22ec2b48cd018605338c3f1bffff",
+    "name": "아이템 막자 모드"
+  },
+  {
+    "id": "ee2426e23fa56f7a695084e1fc07fe6bb03a0b3b0c71c4e1f1b7e7e78e6c6878",
+    "name": "아이템 팀 배틀모드"
+  },
+  {
+    "id": "6f2d79ba8579760af6239ada4fd09c158430625d537676dd0fe07e9934e1d55b",
+    "name": "아이템 미니 개인전"
+  },
+  {
+    "id": "221dec22f320badabd66dc43c3b67c1f88f38e90f4ac2906ed86fd605d78d10a",
+    "name": "스피드 막자 모드"
+  },
+  {
+    "id": "c84b965f5125749735f4c70404f0792248b782b54b2e9356135b7ba35e51e5a6",
+    "name": "데스매치 개인전"
+  },
+  {
+    "id": "d1a35bd884308b370085b22809f1cb7fa8ab3373c20aaa12c40a14491e9e4f21",
+    "name": "이벤트 대박트랙"
+  },
+  {
+    "id": "7b9f0fd5377c38514dbb78ebe63ac6c3b81009d5a31dd569d1cff8f005aa881a",
+    "name": "스피드 개인전"
+  },
+  {
+    "id": "56c651b08836f7c513545e61837ee1ff917d10a8bdbd95a09e5ee5ca2024f157",
+    "name": "쉐도우 스피드 개인전"
+  },
+  {
+    "id": "b0da8c192a6e908b871f65527b074a59652e0ad8525936b5cf1755d9d86d50fd",
+    "name": "복불복 아이템 개인전"
+  },
+  {
+    "id": "224ab54ee8a63940f4df542524ee4059b94efbd3e8ce94f03707ed39294a0e2e",
+    "name": "플래그 개인전"
+  },
+  {
+    "id": "b73122a1e6559949df183992491d440f00272ebecf9c415ceec8197abb936432",
+    "name": "복불복 스피드 개인전"
+  },
+  {
+    "id": "9edf78dd2f844ff6b25e747be9bd29d31b5ad4e06389cfc64b8bc9815bb02610",
+    "name": "데스매치 팀전"
+  },
+  {
+    "id": "196fbff597e92e7454fc1acd1f36936dd94c97e5a57abf513469526399900e78",
+    "name": "복불복 아이템 팀전"
+  },
+  {
+    "id": "826ecdb309f3a2b80a790902d1b133499866d6b933c7deb0916979d1232f968c",
+    "name": "클럽 스피드 팀전"
+  },
+  {
+    "id": "b4dfec547dfd89d2b8f33ad833e1d433a8c85a48d3c4c52ae4855a56eb8d7991",
+    "name": "쉐도우 스피드 팀전"
+  },
+  {
+    "id": "effd66758144a29868663aa50e85d3d95c5bc0147d7fdb9802691c2087f3416e",
+    "name": "스피드 팀전"
+  },
+  {
+    "id": "e7be8820e2836e5779dfb5339956768c04ea6cc5788babb1e993b764b86ccec8",
+    "name": "클럽 아이템 팀전"
+  },
+  {
+    "id": "32f9446c97af9d2d928a16161413b5a500c58304df1bce3ddd94a140335b3348",
+    "name": "아이템 미니 팀전"
+  },
+  {
+    "id": "14e772d195642279cf6c8307125044274db371c1b08fc3dd6553e50d76d2b3aa",
+    "name": "아이템 팀전"
+  },
+  {
+    "id": "247b7b12c1d0bf5fbd17ca4cf2c21d7442459f38937486cad097e3a1fc689d20",
+    "name": "플래그 팀전"
+  },
+  {
+    "id": "8e432e8122a23f4d06a3d43b1cec2fb9d939bb1a5c30b571574ee5f74fda9d66",
+    "name": "복불복 스피드 팀전"
+  },
+  {
+    "id": "e60946660f964b7aadf47691a6c663cc57b2cf8021761c9183aa1fabea1f8537",
+    "name": "1 vs 1 모드"
+  }
+]

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { Provider } from "react-redux";
+import { store } from "./redux/store";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 import Profile from "../components/Profile";
 import VSanimation from "../components/VSanimation";
+import Stats from "../components/Stats";
 
 const Outer = styled.section`
   width: 100%;
@@ -32,6 +33,8 @@ const IconContainer = styled.div`
 const Main = ({ data, updateData }) => {
   const [isTeam, setIsTeam] = useState(false);
   // 개인전인지 팀전인지 여부
+  const [isRetire, setIsRetire] = useState(false);
+  // info/right 내 리타이어 정보들을 노출시킬 것인지 아닌지의 state
 
   return (
     <Outer>
@@ -49,6 +52,7 @@ const Main = ({ data, updateData }) => {
           setIsTeam={setIsTeam}
         />
         <VSanimation />
+        <Stats data={data} />
       </Inner>
     </Outer>
   );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import Profile from "../components/Profile";
+
+const Outer = styled.section`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.025);
+`;
+const Inner = styled.div`
+  width: 1000px;
+  display: flex;
+  flex-direction: column;
+`;
+const ApiInfo = styled.div`
+  height: 50px;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: #1f334a;
+  letter-spacing: -1px;
+`;
+const IconContainer = styled.div`
+  font-size: 13px;
+  margin-right: 5px;
+`;
+
+const Main = ({ data, updateData }) => {
+  const [isTeam, setIsTeam] = useState(false);
+  // 개인전인지 팀전인지 여부
+
+  return (
+    <Outer>
+      <Inner>
+        <ApiInfo>
+          <IconContainer>
+            <FontAwesomeIcon icon={faCircleInfo} />
+          </IconContainer>
+          카트라이더 매치데이터는 최근 1년치 데이터만 확인할 수 있습니다
+        </ApiInfo>
+        <Profile
+          data={data}
+          updateData={updateData}
+          isTeam={isTeam}
+          setIsTeam={setIsTeam}
+        />
+      </Inner>
+    </Outer>
+  );
+};
+
+export default Main;

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -5,6 +5,8 @@ import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 import Profile from "../components/Profile";
 import VSanimation from "../components/VSanimation";
 import Stats from "../components/Stats";
+import Taps from "../components/Tabs";
+import Info from "../components/Info";
 
 const Outer = styled.section`
   width: 100%;
@@ -53,6 +55,8 @@ const Main = ({ data, updateData }) => {
         />
         <VSanimation />
         <Stats data={data} />
+        <Taps isRetire={isRetire} setIsRetire={setIsRetire} />
+        <Info data={data} isTeam={isTeam} isRetire={isRetire} />
       </Inner>
     </Outer>
   );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 import Profile from "../components/Profile";
+import VSanimation from "../components/VSanimation";
 
 const Outer = styled.section`
   width: 100%;
@@ -47,6 +48,7 @@ const Main = ({ data, updateData }) => {
           isTeam={isTeam}
           setIsTeam={setIsTeam}
         />
+        <VSanimation />
       </Inner>
     </Outer>
   );

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { setupListeners } from "@reduxjs/toolkit/dist/query";
+import { datasApi } from "../services/api";
+
+export const store = configureStore({
+  reducer: {
+    [datasApi.reducerPath]: datasApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(datasApi.middleware),
+});
+
+setupListeners(store.dispatch);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,33 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const datasApi = createApi({
+  reducerPath: "datasApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl:
+      "https://joseph-proxy.herokuapp.com/https://api.nexon.co.kr/kart/v1.0",
+    prepareHeaders: (headers) => {
+      headers.set("Authorization", process.env.REACT_APP_API_KEY);
+      return headers;
+    },
+  }),
+  endpoints: (builder) => ({
+    getDatas: builder.query({
+      query: (nickname) => `/users/nickname/${nickname}`,
+    }),
+    getMatchDatas: builder.query({
+      query: (access_Id) => `/users/${access_Id}/matches?limit=50`,
+    }),
+    getPlayerDatas: builder.mutation({
+      query: (match_Id) => ({
+        url: `/matches/${match_Id}`,
+        method: "GET",
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetDatasQuery,
+  useGetMatchDatasQuery,
+  useGetPlayerDatasMutation,
+} = datasApi;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
info-> main

### 변경 사항
1. Loading 기능
api콜 시 나올 Loading UI를 구현했습니다.
rtk query에서 제공하는 isLoading 필드의 boolean값에 따라 Loading UI 생성/제거를 구현했습니다.
![Loading](https://user-images.githubusercontent.com/84559872/161235213-a78e67e5-b08c-4aa1-8bb8-444a2500c8c1.gif)


2. toggle기능 - 리타이어 데이터 filtering
toggle on/off에 따라 리타이어 데이터가 필터링 됩니다.
![toggle](https://user-images.githubusercontent.com/84559872/161235305-af0bfa9f-e110-4910-a9f3-3c4e71bd605e.gif)


3. drawer 기능 
각 match data의 arrow 아이콘을 누름으로써 player data가 담긴 drawer가 나옵니다.
drawer가 on될 때 api콜을 하면서 data를 받습니다. 로딩 중에는 스켈레톤 UI를 구현하였습니다.
![matchdrawer](https://user-images.githubusercontent.com/84559872/161233781-7ee7dafb-b744-459f-853a-7a1dca571c0b.gif)

4. 기타
트랙 전적의 그래프 및 데이터는 아직 구현되지 않았습니다.