### PR TITLE
Fix: 스크롤 끝 감지시 알림글 구현 & Update: Api콜 데이터 캐시 유효기간 조정

### DIFF
--- a/src/components/Right.js
+++ b/src/components/Right.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import MatchDetail from "./MatchDetail";
 import gameType from "../data/gameType.json";
@@ -32,7 +32,10 @@ const Target = styled.div``;
 const Right = ({ data, isTeam, isRetire }) => {
   const matchDatas = data.matches?.[0].matches;
   const [isLoading, setIsLoading] = useState(false);
+  // 로딩 상태 값
   const [matchDatasPiece, setMatchDatas] = useState(matchDatas.slice(0, 10));
+  const [isScrollEnd, setIsScrollEnd] = useState(false);
+  // 스크롤 끝을 감지하는 상태값
 
   const getMoreData = () => {
     if (
@@ -84,6 +87,27 @@ const Right = ({ data, isTeam, isRetire }) => {
     }
   };
 
+  useEffect(() => {
+    let mounted = true;
+    if (mounted) {
+      window.addEventListener("scroll", () => {
+        let scrollLocation = document.documentElement.scrollTop; // 현재 스크롤바 위치
+        let windowHeight = window.innerHeight; // 스크린 창
+        let fullHeight = document.body.scrollHeight; //  margin 값은 포함 x
+
+        if (Math.round(scrollLocation + windowHeight) >= fullHeight) {
+          setIsScrollEnd(true);
+        } else {
+          setIsScrollEnd(false);
+        }
+      });
+    }
+    return () => {
+      mounted = false;
+      setIsScrollEnd(false);
+    };
+  }, []);
+
   return (
     <Container>
       <Matches>
@@ -101,7 +125,10 @@ const Right = ({ data, isTeam, isRetire }) => {
             (matchData) => filteringData(matchData) !== null
           ).length === 0 // 필터링 후 전부 null값이라면
             ? "데이터가 없습니다."
-            : !isLoading // 로딩이 안걸린다면 마지막 데이터
+            : (!isLoading && isScrollEnd) || // 로딩이 안 걸리고 스크롤이 마지막에 위치해있거나,
+              matchDatasPiece.filter(
+                (matchData) => filteringData(matchData) !== null
+              ).length <= 10 // 10개 이하의 데이터만 갖고 있다면
             ? `마지막 데이터입니다.`
             : null}
         </LastData>

--- a/src/services/match.js
+++ b/src/services/match.js
@@ -1,5 +1,13 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+const VALID_CACHE_TIME = 10;
+/*
+매치 데이터를 자주 확인 하는 유저라면,
+매치 게임 하나가 끝나고 바로 전적 데이터를 확인하는 상황도 많을 것으로 예상.
+또한, 다른 유저가 게임이 막 끝난 해당 유저의 매치 기록을 확인하는 상황도 있을 것.
+유저의 불편함이 없도록 캐시 유효기간을 짧게 가져 전적 갱신이 빠르게 가능해야 한다. 
+*/
+
 export const matchApi = createApi({
   reducerPath: "match",
   baseQuery: fetchBaseQuery({
@@ -10,7 +18,7 @@ export const matchApi = createApi({
       return headers;
     },
   }),
-  keepUnusedDataFor: 60,
+  keepUnusedDataFor: VALID_CACHE_TIME,
   endpoints: (builder) => ({
     getMatch: builder.query({
       query: (matchId) => `/matches/${matchId}`,

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,5 +1,8 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+const VALID_CACHE_TIME = 300;
+// 변하지 않는 데이터이고 개별 데이터이기 때문에 캐시 보관 시간이 상대적으로 길어도 상관 없다.
+
 export const userApi = createApi({
   reducerPath: "user",
   baseQuery: fetchBaseQuery({
@@ -10,7 +13,7 @@ export const userApi = createApi({
       return headers;
     },
   }),
-  keepUnusedDataFor: 60,
+  keepUnusedDataFor: VALID_CACHE_TIME,
   endpoints: (builder) => ({
     getUser: builder.query({
       query: (nickname) => `/users/nickname/${nickname}`,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 제거
### 반영 브랜치
ex) Router -> main

### 변경 사항
1. 캐시 유효시간 상수 const로 관리
캐시 유효기간을 VALID_CACHE_TIME이라는 상수 변수로 만들어 관리하도록 하였습니다.<br><br>
2. Api콜 데이터 캐시 유효기간 조정
유저의 매치 리스트 데이터를 받아올 경우 캐시 유효기간을 10초로 조정하였습니다.
매치 데이터를 자주 확인 하는 유저라면, 매치 게임 하나가 끝나고 바로 전적 데이터를 갱신 및 확인하는 상황도 있을 것으로 예상합니다.
유저가 유효기간이 지날 때까지 기다리는 불편함이 없도록 캐시 유효기간을 짧게 10초로 하여 전적 갱신이 빠르게 가능하도록 하였습니다.<br>
반면, 특정 매치의 상세정보의 경우 유효 기간을 300초로 조정하였습니다. 
해당 데이터는 갱신으로 인해 변화될 여지가 없는 데이터이기 때문에 캐시 유효기간을 길게 가져갔습니다.<br><br>
3. 스크롤 끝 감지시에만 "마지막 데이터..."알림 구현
이전에는 loading 상태값이 false 일 때 "마지막 데이터입니다." 라는 문구가 나오도록 설정하였습니다.
때문에 사용자가 스크롤을 느리게 내릴 경우, 무한스크롤이 발동되기 전에 "마지막 데이터입니다." 문구가 보였기 때문에
모든 데이터를 봤다고 착각할 수 있다는 결함이 있었습니다.
scrollHeight, innerHeight 등 속성을 사용하여 스크롤이 끝 부분에 위치했을 때를 감지하도록 하였습니다.
스크롤이 끝 부분에 위치했을 때와 동시에, loading 중이 아닐 때만 "마지막 데이터입니다."문구가 나오도록 설정하였습니다.